### PR TITLE
Run CI with MacVim on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+os:
+  - linux
+  - osx
+
 env:
   - HEAD=yes
   - HEAD=no
@@ -23,31 +27,40 @@ cache:
 
 install:
   - |
-    if [ x"${HEAD}" = "xyes" ]; then
-      if [ -d /tmp/vim/.git ]; then
-        cd /tmp/vim
-        git fetch
-        if git diff --exit-code --quiet ..origin/master; then
-          need_build=0
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+      if [ x"${HEAD}" = "xyes" ]; then
+        if [ -d /tmp/vim/.git ]; then
+          cd /tmp/vim
+          git fetch
+          if git diff --exit-code --quiet ..origin/master; then
+            need_build=0
+          else
+            git reset --hard origin/master
+            git clean -dfx
+            need_build=1
+          fi
         else
-          git reset --hard origin/master
-          git clean -dfx
+          git clone --depth 1 --single-branch https://github.com/vim/vim /tmp/vim
+          cd /tmp/vim
           need_build=1
         fi
+        if [ "${need_build}" = "1" ]; then
+          ./configure --prefix="$PWD/build" --with-features=huge \
+            --enable-perlinterp --enable-pythoninterp --enable-python3interp \
+            --enable-rubyinterp --enable-luainterp --enable-fail-if-missing
+          make -j2
+          make install
+        fi
+        export PATH=$PWD/build/bin:$PATH
+        cd "${TRAVIS_BUILD_DIR}"
+      fi
+    else
+      brew update
+      if [ x"${HEAD}" = "xyes" ]; then
+        brew install macvim --with-lua --with-override-system-vim --HEAD
       else
-        git clone --depth 1 --single-branch https://github.com/vim/vim /tmp/vim
-        cd /tmp/vim
-        need_build=1
+        brew install macvim --with-lua --with-override-system-vim
       fi
-      if [ "${need_build}" = "1" ]; then
-        ./configure --prefix="$PWD/build" --with-features=huge \
-          --enable-perlinterp --enable-pythoninterp --enable-python3interp \
-          --enable-rubyinterp --enable-luainterp --enable-fail-if-missing
-        make -j2
-        make install
-      fi
-      export PATH=$PWD/build/bin:$PATH
-      cd "${TRAVIS_BUILD_DIR}"
     fi
 
 script:


### PR DESCRIPTION
[Travis CI の OS X サポート](https://docs.travis-ci.com/user/osx-ci-environment/) を使って OS X 上でのテストを有効にしてみました．どうやら問題なくテストが実行できているみたいです．

https://travis-ci.org/rhysd/vim-themis/builds/111448720

普段使いが OS X なので OS X でも CI しておいてもらえると助かるのですが，どうでしょうか？ Vim プラグインを OS X 上でテストするサンプルにもなると思います．

thinca さんは Mac ユーザではないので Homebrew とか知らないと思うので，もし何か今後問題があれば僕のほうに投げてもらって大丈夫です．
ちなみに OS X のワーカーはコンテナベースの Linux ワーカーみたいに立ち上がりが速くないので，ビルド時間が1分半ぐらいから3分ぐらいに延びます．