### PR TITLE
Add $THEMIS_ARGS to support extra arguments

### DIFF
--- a/bin/themis
+++ b/bin/themis
@@ -5,6 +5,7 @@
 # License: zlib License
 
 : "${THEMIS_VIM:=vim}"
+: "${THEMIS_ARGS:=-e -s}"
 
 if ! type realpath >/dev/null 2>&1; then
 	realpath() {
@@ -21,4 +22,4 @@ if [ ! -f "${STARTUP_SCRIPT}" ]; then
 	exit 2
 fi
 
-"${THEMIS_VIM}" -u NONE -i NONE -n -N -e -s --cmd "source ${STARTUP_SCRIPT}" -- "$@" 3>&1 1>&2 2>&3 3>&-
+"${THEMIS_VIM}" -u NONE -i NONE -n -N ${THEMIS_ARGS} --cmd "source ${STARTUP_SCRIPT}" -- "$@" 3>&1 1>&2 2>&3 3>&-

--- a/bin/themis.bat
+++ b/bin/themis.bat
@@ -8,6 +8,7 @@ setlocal
 
 if "%THEMIS_HOME%"== "" call :get_realpath
 if "%THEMIS_VIM%"== "" set THEMIS_VIM=vim
+if "%THEMIS_ARGS%"== "" set THEMIS_ARGS=-e -s
 
 set STARTUP_SCRIPT="%THEMIS_HOME%\macros\themis_startup.vim"
 if not exist "%STARTUP_SCRIPT%" (
@@ -16,7 +17,7 @@ if not exist "%STARTUP_SCRIPT%" (
 )
 
 rem FIXME: Some wrong case exists in passing the argument list.
-%THEMIS_VIM% -u NONE -i NONE -n -N -e -s --cmd "source %STARTUP_SCRIPT%" -- %* 2>&1
+%THEMIS_VIM% -u NONE -i NONE -n -N %THEMIS_ARGS% --cmd "source %STARTUP_SCRIPT%" -- %* 2>&1
 exit /b %ERRORLEVEL%
 
 :get_realpath

--- a/doc/themis.txt
+++ b/doc/themis.txt
@@ -202,7 +202,9 @@ $THEMIS_VIM					*$THEMIS_VIM*
 
 $THEMIS_ARGS					*$THEMIS_ARGS*
 	Extra arguments passed to |$THEMIS_VIM|. "-e -s" is used when this is
-	empty.
+	empty. Note that chainging the value may cause invalid test run.
+	Change the value of this variable with your own responsibility.
+	
 
 ------------------------------------------------------------------------------
 THEMISRC					*themis-themisrc*

--- a/doc/themis.txt
+++ b/doc/themis.txt
@@ -200,6 +200,10 @@ $THEMIS_HOME					*$THEMIS_HOME*
 $THEMIS_VIM					*$THEMIS_VIM*
 	The path to vim command.  "vim" is used when this is empty.
 
+$THEMIS_ARGS					*$THEMIS_ARGS*
+	Extra arguments passed to |$THEMIS_VIM|. "-e -s" is used when this is
+	empty.
+
 ------------------------------------------------------------------------------
 THEMISRC					*themis-themisrc*
 


### PR DESCRIPTION
This would close #37 and #34.

Now users can control extra command arguments passed to `$THEMIS_VIM`.
For example, the following use Neovim to run themis tests. `$THEMIS_ARGS` is required while Neovim requires `--headless` option to work with themis.

```
$ cd vim-themis
$ THEMIS_VIM=nvim THEMIS_ARGS="-e --headless" themis
1..314
ok 1 - helper expect .to_be_true() checks_value_is_true
ok 2 - helper expect .to_be_true() checks_value_strictly
ok 3 - helper expect .to_be_false() checks_value_is_false
ok 4 - helper expect .to_be_false() checks_value_strictly
ok 5 - helper expect .to_be_truthy() checks_value_is_not_zero
ok 6 - helper expect .to_be_truthy() throws_a_report_when_value_is_zero_or_not_a_number
ok 7 - helper expect .to_equal() checks_values_are_equal
ok 8 - helper expect .to_equal() throws_a_report_when_values_are_differnt
ok 9 - helper expect .to_be_same() checks_values_have_same_instance
ok 10 - helper expect .to_be_same() throws_a_report_when_values_are_differnt_instances
ok 11 - helper expect .to_match() checks_value_matches_with_regex
ok 12 - helper expect .to_match() throws_a_report_when_value_is_not_string
ok 13 - helper expect .to_match() throws_a_report_when_value_does_not_match
ok 14 - helper expect .to_have_length() checks_length_of_string
ok 15 - helper expect .to_have_length() checks_length_of_list
ok 16 - helper expect .to_have_length() checks_length_of_dict
ok 17 - helper expect .to_have_length() throws_a_report_when_length_is_mismatch
ok 18 - helper expect .to_have_length() throws_a_report_when_first_argument_is_not_valid
ok 19 - helper expect .to_have_key() checks_key_exists_in_dict
ok 20 - helper expect .to_have_key() checks_index_exists_in_array
ok 21 - helper expect .to_have_key() throws_a_report_when_key_is_not_exist_in_dict
ok 22 - helper expect .to_have_key() throws_a_report_when_index_is_not_exist_in_array
ok 23 - helper expect .to_exist() checks_existence
ok 24 - helper expect .to_exist() throws_report_when_the_value_does_not_to_exist
ok 25 - helper expect .to_be_empty() checks_empty
ok 26 - helper expect .to_be_empty() throws_report_when_the_value_is_not_empty
ok 27 - helper expect .to_be_greater_than(_or_equal)/.to_be_less_than(_or_equal) checks_value_compared_with_the_other
ok 28 - helper expect .to_be_greater_than(_or_equal)/.to_be_less_than(_or_equal) throws_a_report_when_comparison_result_is_false
ok 29 - helper expect .to_be_number() checks_type_of_value
ok 30 - helper expect .to_be_number() throws_a_report_when_type_is_mismatch
ok 31 - helper expect .to_be_string() checks_type_of_value
ok 32 - helper expect .to_be_string() throws_a_report_when_type_is_mismatch
ok 33 - helper expect .to_be_list() checks_type_of_value
ok 34 - helper expect .to_be_list() throws_a_report_when_type_is_mismatch
ok 35 - helper expect .to_be_dict() checks_type_of_value
ok 36 - helper expect .to_be_dict() throws_a_report_when_type_is_mismatch
ok 37 - helper expect .to_be_func() checks_type_of_value
ok 38 - helper expect .to_be_func() throws_a_report_when_type_is_mismatch
ok 39 - helper expect .to_be_float() checks_type_of_value
ok 40 - helper expect .to_be_float() throws_a_report_when_type_is_mismatch
ok 41 - helper expect custom matcher can_be_defined
ok 42 - helper expect custom matcher provides_failre_message_definition
ok 43 - vimspec-style order of examples is called in first
ok 44 - vimspec-style order of examples is called in second
ok 45 - vimspec-style order of examples is called in third
ok 46 - vimspec-style order of examples is called in fourth
ok 47 - vimspec-style order of examples is called in fifth
ok 48 - vimspec-style order of examples is called in sixth
ok 49 - vimspec-style order of examples is called in seventh
ok 50 - vimspec-style order of examples is called in eighth
ok 51 - vimspec-style order of examples is called in ninth
ok 52 - vimspec-style order of examples is called in tenth
ok 53 - vimspec-style order of bundles first bundle is called in first
ok 54 - vimspec-style order of bundles second bundle is called in second
ok 55 - vimspec-style order of bundles third bundle is called in third
ok 56 - vimspec-style order of bundles fourth bundle is called in fourth
ok 57 - vimspec-style order of bundles fifth bundle is called in fifth
ok 58 - supporter-stats counts number of total tests
ok 59 - supporter-stats counts number of passed tests
ok 60 - supporter-stats counts number of failed tests
ok 61 - supporter-stats counts number of pending tests
ok 62 - supporter-stats shows the test statistics
ok 63 - supporter-builtin_assert handles assert_true()
ok 64 - helper-assert .skip() throws a skip report with message
ok 65 - helper-assert .todo() throws a todo report with message
ok 66 - helper-assert .todo() uses default message when the message is omitted
ok 67 - helper-assert .fail() throws a error report with message
ok 68 - helper-assert .true() checks value is true
ok 69 - helper-assert .true() checks value strictly
ok 70 - helper-assert .true() returns truthy value when check was successful
ok 71 - helper-assert .true() accepts an optional message
ok 72 - helper-assert .false() checks value is false
ok 73 - helper-assert .false() checks value strictly
ok 74 - helper-assert .false() returns truthy value when check was successful
ok 75 - helper-assert .false() accepts an optional message
ok 76 - helper-assert .truthy() checks value is not zero
ok 77 - helper-assert .truthy() throws a report when value is zero or not a number
ok 78 - helper-assert .truthy() returns truthy value when check was successful
ok 79 - helper-assert .truthy() accepts an optional message
ok 80 - helper-assert .falsy() checks value is zero
ok 81 - helper-assert .falsy() throws a report when value is not zero or not a number
ok 82 - helper-assert .falsy() returns truthy value when check was successful
ok 83 - helper-assert .falsy() accepts an optional message
ok 84 - helper-assert .compare() does not throw a report when comparing succeeded
ok 85 - helper-assert .compare() throws a report when comparing failed
ok 86 - helper-assert .compare() throws a report when error occurred
ok 87 - helper-assert .compare() returns truthy value when check was successful
ok 88 - helper-assert .compare() accepts an optional message
ok 89 - helper-assert .equals() checks actual equals to expect
ok 90 - helper-assert .equals() throws a report when values are not equivalent
ok 91 - helper-assert .equals() returns truthy value when check was successful
ok 92 - helper-assert .equals() accepts an optional message
ok 93 - helper-assert .equals() with string and number checks string is valid as number
ok 94 - helper-assert .not_equals() checks actual not equals to expect
ok 95 - helper-assert .not_equals() throws a report when values are equivalent
ok 96 - helper-assert .not_equals() returns truthy value when check was successful
ok 97 - helper-assert .not_equals() accepts an optional message
ok 98 - helper-assert .not_equals() with string and number checks string is valid as number
ok 99 - helper-assert .same() checks actual value and expected value are same
ok 100 - helper-assert .same() throws a report when values are not same
ok 101 - helper-assert .same() returns truthy value when check was successful
ok 102 - helper-assert .same() accepts an optional message
ok 103 - helper-assert .not_same() checks actual value and expected value are not same
ok 104 - helper-assert .not_same() throws a report when values are same
ok 105 - helper-assert .not_same() returns truthy value when check was successful
ok 106 - helper-assert .not_same() accepts an optional message
ok 107 - helper-assert .match() checks actual value matches to pattern
ok 108 - helper-assert .match() throws a report when value does not match to pattern
ok 109 - helper-assert .match() returns truthy value when check was successful
ok 110 - helper-assert .match() accepts an optional message
ok 111 - helper-assert .not_match() checks actual value does not match to pattern
ok 112 - helper-assert .not_match() throws a report when value matches to pattern
ok 113 - helper-assert .not_match() returns truthy value when check was successful
ok 114 - helper-assert .not_match() accepts an optional message
ok 115 - helper-assert .is_number() checks type of value is number
ok 116 - helper-assert .is_number() throws a report when type of value is not number
ok 117 - helper-assert .is_number() returns truthy value when check was successful
ok 118 - helper-assert .is_number() accepts an optional message
ok 119 - helper-assert .is_not_number() checks type of value is not number
ok 120 - helper-assert .is_not_number() throws a report when type of value is number
ok 121 - helper-assert .is_not_number() returns truthy value when check was successful
ok 122 - helper-assert .is_not_number() accepts an optional message
ok 123 - helper-assert .is_string() checks type of value is string
ok 124 - helper-assert .is_string() throws a report when type of value is not string
ok 125 - helper-assert .is_string() returns truthy value when check was successful
ok 126 - helper-assert .is_string() accepts an optional message
ok 127 - helper-assert .is_not_string() checks type of value is not string
ok 128 - helper-assert .is_not_string() throws a report when type of value is string
ok 129 - helper-assert .is_not_string() returns truthy value when check was successful
ok 130 - helper-assert .is_not_string() accepts an optional message
ok 131 - helper-assert .is_func() checks type of value is func
ok 132 - helper-assert .is_func() throws a report when type of value is not func
ok 133 - helper-assert .is_func() returns truthy value when check was successful
ok 134 - helper-assert .is_func() accepts an optional message
ok 135 - helper-assert .is_not_func() checks type of value is not func
ok 136 - helper-assert .is_not_func() throws a report when type of value is func
ok 137 - helper-assert .is_not_func() returns truthy value when check was successful
ok 138 - helper-assert .is_not_func() accepts an optional message
ok 139 - helper-assert .is_list() checks type of value is list
ok 140 - helper-assert .is_list() throws a report when type of value is not list
ok 141 - helper-assert .is_list() returns truthy value when check was successful
ok 142 - helper-assert .is_list() accepts an optional message
ok 143 - helper-assert .is_not_list() checks type of value is not list
ok 144 - helper-assert .is_not_list() throws a report when type of value is list
ok 145 - helper-assert .is_not_list() returns truthy value when check was successful
ok 146 - helper-assert .is_not_list() accepts an optional message
ok 147 - helper-assert .is_dict() checks type of value is dict
ok 148 - helper-assert .is_dict() throws a report when type of value is not dict
ok 149 - helper-assert .is_dict() returns truthy value when check was successful
ok 150 - helper-assert .is_dict() accepts an optional message
ok 151 - helper-assert .is_not_dict() checks type of value is not dict
ok 152 - helper-assert .is_not_dict() throws a report when type of value is dict
ok 153 - helper-assert .is_not_dict() returns truthy value when check was successful
ok 154 - helper-assert .is_not_dict() accepts an optional message
ok 155 - helper-assert .is_float() checks type of value is float
ok 156 - helper-assert .is_float() throws a report when type of value is not float
ok 157 - helper-assert .is_float() returns truthy value when check was successful
ok 158 - helper-assert .is_float() accepts an optional message
ok 159 - helper-assert .is_not_float() checks type of value is not float
ok 160 - helper-assert .is_not_float() throws a report when type of value is float
ok 161 - helper-assert .is_not_float() returns truthy value when check was successful
ok 162 - helper-assert .is_not_float() accepts an optional message
ok 163 - helper-assert .type_of() checks type of value
ok 164 - helper-assert .type_of() accepts name of type as case insensitive
ok 165 - helper-assert .type_of() accepts one or more names by list
ok 166 - helper-assert .type_of() throws a report when type is mismatch
ok 167 - helper-assert .type_of() returns truthy value when check was successful
ok 168 - helper-assert .type_of() accepts an optional message
ok 169 - helper-assert .length_of() checks length of string
ok 170 - helper-assert .length_of() checks length of list
ok 171 - helper-assert .length_of() checks length of dict
ok 172 - helper-assert .length_of() throws a report when length is mismatch
ok 173 - helper-assert .length_of() throws a report when first argument is not valid
ok 174 - helper-assert .length_of() returns truthy value when check was successful
ok 175 - helper-assert .length_of() accepts an optional message
ok 176 - helper-assert .has_key() checks key exists in dict
ok 177 - helper-assert .has_key() checks index exists in array
ok 178 - helper-assert .has_key() throws a report when key is not exist in dict
ok 179 - helper-assert .has_key() throws a report when index is not exist in array
ok 180 - helper-assert .has_key() throws a report when first argumentis not dict or array
ok 181 - helper-assert .has_key() returns truthy value when check was successful
ok 182 - helper-assert .has_key() accepts an optional message
ok 183 - helper-assert .key_exists() checks key exists in dict
ok 184 - helper-assert .key_exists() throws a report when key is not exist in dict
ok 185 - helper-assert .key_exists() throws a report when first argumentis not dict
ok 186 - helper-assert .key_exists() returns truthy value when check was successful
ok 187 - helper-assert .key_exists() accepts an optional message
ok 188 - helper-assert .key_not_exists() checks key does not exist in dict
ok 189 - helper-assert .key_not_exists() throws a report when key exists in dict
ok 190 - helper-assert .key_not_exists() throws a report when first argument is not dict
ok 191 - helper-assert .key_not_exists() returns truthy value when check was successful
ok 192 - helper-assert .key_not_exists() accepts an optional message
ok 193 - helper-assert .exists() throws report when the value does not exists
ok 194 - helper-assert .exists() does not throw report when the value exists
ok 195 - helper-assert .exists() returns truthy value when check was successful
ok 196 - helper-assert .exists() accepts an optional message
ok 197 - helper-assert .empty() throws report when the value is not empty
ok 198 - helper-assert .empty() passes when the value is empty
ok 199 - helper-assert .empty() returns truthy value when check was successful
ok 200 - helper-assert .empty() accepts an optional message
ok 201 - helper-assert .not_empty() throws report when the value is empty
ok 202 - helper-assert .not_empty() passes when the value is empty
ok 203 - helper-assert .not_empty() returns truthy value when check was successful
ok 204 - helper-assert .not_empty() accepts an optional message
ok 205 - util #stack_info() can parse tail line number
ok 206 - util #stack_info() can parse nested function line number
ok 207 - util #stack_info() accepts old stacktrace
ok 208 - util #parse_callstack() can parse sfile
ok 209 - util #parse_callstack() can parse throwpoint
ok 210 - util #funcdata() takes a function by name
ok 211 - util #funcdata() takes a function by funcref
ok 212 - util #funcdata() returns the data with "exists" flag as false when the function is already deleted
ok 213 - util #funcdata() returns data that contains exists flag
ok 214 - util #funcdata() returns data that contains filename
ok 215 - util #funcdata() returns data that contains funcname
ok 216 - util #funcdata() returns data that contains signature info
ok 217 - util #funcdata() returns data that contains arguments info
ok 218 - util #funcdata() returns data that contains arity
ok 219 - util #funcdata() returns data that contains has_extra_arguments flag
ok 220 - util #funcdata() returns data that contains is_dict flag
ok 221 - util #funcdata() returns data that contains is_abort flag
ok 222 - util #funcdata() returns data that contains has_range flag
ok 223 - util #funcdata() returns data that contains body
ok 224 - util #is_funcname() checks the argument is name of function
ok 225 - util #funcname() returns function name from Funcref
ok 226 - util #get_full_title() returns the full title of a suite or a report
ok 227 - util #sortuniq() sorts the list, and removes duplicated item from the list
ok 228 - Report .get_full_title() returns full title of a target test
ok 229 - Report .get_title() returns title of a target test
ok 230 - Report .get_message() with no exceptions returns empty string
ok 231 - Report .get_message() with an exception returns the message of exception
ok 232 - Report .get_message() with two exceptions returns the message of all exceptions
ok 233 - Bundle has a title
ok 234 - Bundle tree structure can make a new child bundle by themis#bundle#new()
ok 235 - Bundle tree structure can add a new child bundle by .add_child()
ok 236 - Bundle tree structure child bundle can access to parent bundle
ok 237 - Bundle tree structure child bundle can be removed from parent module
ok 238 - Bundle tree structure child bundle can change a parent bundle
ok 239 - Bundle style can have a style
ok 240 - Bundle style inherits to child bundles
ok 241 - Bundle test entries can get all test entries
ok 242 - Bundle test entries can select the tests
ok 243 - Bundle test entries with nested bundles can count total test count
ok 244 - Bundle test entries with nested bundles can select the tests in recursive
ok 245 - Bundle test entries with nested bundles can check the bundle is empty
ok 246 - Bundle test entries with nested bundles can reverse the filter
ok 247 - Bundle test entry may have a description
ok 248 - Bundle test entry uses a description or a name for title
ok 249 - Bundle test entry can get full title which includes bundle titles
ok 250 - Bundle #is_bundle() can check the {obj} is a bundle or not
ok 251 - hook is_called_in_order
ok 252 - hook with_parent_is_called_in_order
ok 253 - Emitter #add_listener() adds a listener
ok 254 - Emitter #remove_listener() removes a listener
ok 255 - Emitter #remove_all_listeners() removes all listeners
ok 256 - Emitter #emit() with no listeners has no effect
ok 257 - Emitter #emit() with a listener which has "foo" event {event} is "foo" calls "foo" event handler
ok 258 - Emitter #emit() with a listener which has "foo" event {event} is "foo" doesn't call "bar" event handler
ok 259 - Emitter #emit() with a listener which has "foo" event {event} is "foo" receives the argument
ok 260 - Emitter #emit() with two or more listeners calls all listeners
ok 261 - Emitter #emit() with a listener which has wildcard event receives all events
ok 262 - Emitter #emit() with a listener which has wildcard event and has "foo" event doesn't receive the defined event
ok 263 - Emitter #emitting() when event is emitting returns emitting event name
ok 264 - Emitter #emitting() when event is not emitting returns empty string
ok 265 - Emitter #emitting() when an error occurred while emitting keeps the value
ok 266 - helper command :Assert check_the_argument_is_truthy
ok 267 - helper command :Assert can_use_double_quote_in_argument
ok 268 - helper command :Assert throw_a_report_when_the_argument_is_not_truthy
ok 269 - helper command :Assert can_access_to_function_local_scope
ok 270 - helper command :Assert can_access_to_with_scope
ok 271 - helper command :Throws detect_exception_in_expr
ok 272 - helper command :Throws detect_exception_in_command
ok 273 - helper command :Throws can_check_exception
ok 274 - helper command :Throws can_use_double_quote_in_argument
ok 275 - helper command :Fail fails_a_test_with_message
ok 276 - helper command :Fail can_not_omit_message
ok 277 - helper command :TODO fails_a_test_as_todo_with_message
ok 278 - helper command :TODO uses_default_message_when_the_message_is_omitted
ok 279 - helper command :Skip fails_a_test_with_message
ok 280 - helper command :Skip can_not_omit_message
ok 281 - Runner events with no test is emitted in order
ok 282 - Runner events with some tests is emitted in order
ok 283 - vimspec-style supports lexical scope can access to the variable
ok 284 - vimspec-style supports lexical scope does not taint the global scope
ok 285 - vimspec-style supports lexical scope in the child block can access to the variable
ok 286 - vimspec-style supports lexical scope in before block can change the variable
ok 287 - vimspec-style supports lexical scope before each block is shared the scope with before all block
ok 288 - vimspec-style supports lexical scope before each block is separate every test
ok 289 - vimspec-style supports lexical scope between before each block and body shares the variable instance
ok 290 - vimspec-style supports lexical scope the execution order of nested contexts a deep context is called in order
ok 291 - vimspec-style supports lexical scope the execution order of nested contexts a deep context is separate from previous test
ok 292 - vimspec-style supports lexical scope the execution order of nested contexts an other context is separate from other context
ok 293 - helper-scope .funcs() with {path} is relative path returns a dictionary
ok 294 - helper-scope .funcs() with {path} is relative path contains "hello" function
ok 295 - helper-scope .funcs() with {path} is full path returns a dictionary
ok 296 - helper-scope .funcs() with {path} is full path contains "hello" function
ok 297 - option #default() returns new dictionary always
ok 298 - option #empty_options() returns empty options
ok 299 - option #merge() merges two options
ok 300 - order test first
ok 301 - order test second
ok 302 - order test third
ok 303 - order test fourth
ok 304 - order test fifth
ok 305 - order test sixth
ok 306 - order test seventh
ok 307 - order test eighth
ok 308 - order test ninth
ok 309 - order test tenth
ok 310 - order nested_bundle first count
ok 311 - order nested_bundle second count
ok 312 - order nested_bundle third count
ok 313 - order nested_bundle fourth count
ok 314 - order nested_bundle fifth count

# tests 314
# passes 314
```