### PR TITLE
Add scope.vars() to refer script-local variables

### DIFF
--- a/autoload/themis/helper/scope.vim
+++ b/autoload/themis/helper/scope.vim
@@ -14,6 +14,10 @@ function! s:helper.funcs(path) abort
   return s:Local.sfuncs(a:path)
 endfunction
 
+function! s:helper.vars(path) abort
+  return s:Local.svars(a:path)
+endfunction
+
 function! themis#helper#scope#new(runner) abort
   return  deepcopy(s:helper)
 endfunction

--- a/doc/themis.txt
+++ b/doc/themis.txt
@@ -926,7 +926,9 @@ scope.vars({path})			*themis-helper-scope-vars()*
 	let s:scope = themis#helper('scope')
 	let s:myvars = s:scope.vars('autoload/myvars.vim')
 	echo s:myvars.foo  " echo s:foo in myvars.vim
-
+<
+	CAUTION: vars() will temporarily overwrite the target file and
+	restore the file, so please be careful if you want to use it.
 
 ==============================================================================
 REPORTER					*themis-reporter*

--- a/doc/themis.txt
+++ b/doc/themis.txt
@@ -918,6 +918,14 @@ scope.funcs({path})			*themis-helper-scope-funcs()*
 	let s:myfuncs = s:scope.funcs('autoload/myfuncs.vim')
 	call s:myfuncs.foo()  " calls s:foo() in myfuncs.vim
 
+scope.vars({path})			*themis-helper-scope-vars()*
+	Returns a dictionary which contains |script-local| variables with
+	{path}.
+	{path} is a full path or relative path from 'runtimepath'.
+>
+	let s:scope = themis#helper('scope')
+	let s:myvars = s:scope.vars('autoload/myvars.vim')
+	echo s:myvars.foo  " echo s:foo in myvars.vim
 
 
 ==============================================================================

--- a/test/fixture/scope.vim
+++ b/test/fixture/scope.vim
@@ -1,3 +1,5 @@
 function! s:hello(name) abort
   return 'Hello, ' . a:name
 endfunction
+
+let s:foo = 'foo'

--- a/test/helper/scope.vimspec
+++ b/test/helper/scope.vimspec
@@ -38,4 +38,40 @@ Describe helper-scope
       End
     End
   End
+
+  Describe .vars()
+    Context with {path} is relative path
+      Before
+        let vars = s:scope.vars('test/fixture/scope.vim')
+      End
+
+      It returns a dictionary
+        Assert IsDict(vars)
+      End
+
+      It contains "foo" variable
+        Assert KeyExists(vars, 'foo')
+        Assert IsString(vars.foo)
+        Assert Equals(vars.foo, 'foo')
+      End
+    End
+
+    Context with {path} is full path
+      Before
+        let paths = globpath(&runtimepath, 'test/fixture/scope.vim')
+        let path = split(paths, "\n")[0]
+        let vars = s:scope.vars(path)
+      End
+
+      It returns a dictionary
+        Assert IsDict(vars)
+      End
+
+      It contains "foo" variable
+        Assert KeyExists(vars, 'foo')
+        Assert IsString(vars.foo)
+        Assert Equals(vars.foo, 'foo')
+      End
+    End
+  End
 End


### PR DESCRIPTION
I have not used `scope` helper while because of this. I sometime need to refer script-local variables and themis's `scope` helper did not provide a way.

It is better to support `ScriptLocal.svars()` as like `ScriptLocal.sfuncs()` I think.
What is your opinion?