### PR TITLE
Add 'global' helper to register events globally

### DIFF
--- a/autoload/themis/helper/global.vim
+++ b/autoload/themis/helper/global.vim
@@ -1,0 +1,69 @@
+let s:event = {
+      \ 'globals': [],
+      \}
+
+function! s:event.start(runner) abort
+  for global in self.globals
+    if has_key(global, 'initialize')
+      call global.initialize()
+    endif
+  endfor
+endfunction
+
+function! s:event.before_suite(bundle) abort
+  for global in self.globals
+    if has_key(global, 'before')
+      call global.before()
+    endif
+  endfor
+endfunction
+
+function! s:event.before_test(bundle, entry) abort
+  for global in self.globals
+    if has_key(global, 'before_each')
+      call global.before_each()
+    endif
+  endfor
+endfunction
+
+function! s:event.end(runner) abort
+  for global in self.globals
+    if has_key(global, 'finalize')
+      call global.finalize()
+    endif
+  endfor
+endfunction
+
+function! s:event.after_suite(bundle) abort
+  for global in self.globals
+    if has_key(global, 'after')
+      call global.after()
+    endif
+  endfor
+endfunction
+
+function! s:event.after_test(bundle, entry) abort
+  for global in self.globals
+    if has_key(global, 'after_each')
+      call global.after_each()
+    endif
+  endfor
+endfunction
+
+
+let s:helper = {
+      \ 'event': s:event,
+      \}
+
+function! s:helper.with(globals) abort
+  let globals = type(a:globals) == 3 ? a:globals : [a:globals]
+  call extend(self.event.globals, globals)
+  return self
+endfunction
+
+
+function! themis#helper#global#new(runner) abort
+  let helper = deepcopy(s:helper)
+  call a:runner.add_event(helper.event)
+  return helper
+endfunction

--- a/doc/themis.txt
+++ b/doc/themis.txt
@@ -918,8 +918,60 @@ scope.funcs({path})			*themis-helper-scope-funcs()*
 	let s:myfuncs = s:scope.funcs('autoload/myfuncs.vim')
 	call s:myfuncs.foo()  " calls s:foo() in myfuncs.vim
 
+-----------------------------------------------------------------------------
+GLOBAL							*themis-helper-global*
 
+Global-helper provides a way to register before/after type events globally.
+Not like |themis-style-basic-test-name|, events registered with this helper
+are registered through the entire tests.
 
+The following special situations are supported.
+
+- initialize()
+  - This is called before a first test of a first suite
+- before()
+  - This is called before a first test of each suite
+- before_each()
+  - This is called before each test of each suite
+- after_each()
+  - This is called after each test of each suite
+- after()
+  - This is called after a last test of each suite
+- finalize()
+  - This is called after a last test of a last suite
+
+global.with({events})				*themis-helper-global-with()*
+	Add situations in a {events} dictionary globally.
+>
+	let s:events = {}
+
+	function! s:events.initialize() abort
+	  call themis#log('Initialize')
+	endfunction
+
+	function! s:events.before() abort
+	  call themis#log('Before')
+	endfunction
+
+	function! s:events.before_each() abort
+	  call themis#log('Before each')
+	endfunction
+
+	function! s:events.after_each() abort
+	  call themis#log('After each')
+	endfunction
+
+	function! s:events.after() abort
+	  call themis#log('After')
+	endfunction
+
+	function! s:events.finalize() abort
+	  call themis#log('Finalize')
+	endfunction
+
+	" Register global event
+	call themis#helper('global').with(s:events)
+<
 ==============================================================================
 REPORTER					*themis-reporter*
 


### PR DESCRIPTION
To solve #26. I create a 'global' helper which can register events globally like:

	let s:events = {}

	function! s:events.initialize() abort
	  call themis#log('Initialize')
	endfunction

	function! s:events.before() abort
	  call themis#log('Before')
	endfunction

	function! s:events.before_each() abort
	  call themis#log('Before each')
	endfunction

	function! s:events.after_each() abort
	  call themis#log('After each')
	endfunction

	function! s:events.after() abort
	  call themis#log('After')
	endfunction

	function! s:events.finalize() abort
	  call themis#log('Finalize')
	endfunction

	" Register global event
	call themis#helper('global').with(s:events)
