### PR TITLE
Remove bashism and handle errors as fatal in the shell script

### DIFF
--- a/bin/themis
+++ b/bin/themis
@@ -4,17 +4,34 @@
 # Author : thinca <thinca+vim@gmail.com>
 # License: zlib License
 
+set -e
+
 : "${THEMIS_VIM:=vim}"
 : "${THEMIS_ARGS:=-e -s}"
 
-if ! type realpath >/dev/null 2>&1; then
-	realpath() {
+if [ -z "${THEMIS_HOME+x}" ]; then
+	if realpath "$0" >/dev/null 2>&1; then
+		THEMIS_BIN=$(realpath "$0")
+	elif readlink -f "$0" >/dev/null 2>&1; then
+		THEMIS_BIN=$(readlink -f "$0")
+	elif ! command -v readlink >/dev/null 2>&1; then
+		WORKDIR=$(pwd)
+		THEMIS_BIN=$0
+		while [ -L "$THEMIS_BIN" ]; do
+			cd "$(dirname "$THEMIS_BIN")"
+			THEMIS_BIN=$(readlink "$THEMIS_BIN")
+		done
+		cd "$(dirname "$THEMIS_BIN")"
+		THEMIS_BIN="$(pwd -P)/$(basename "$THEMIS_BIN")"
+		cd "$WORKDIR"
+	elif command -v "${THEMIS_VIM}" >/dev/null 2>&1; then
 		# NOTE: use X to avoid "XSMP opening connection" message.
-		"${THEMIS_VIM}" -u NONE -i NONE -N -X -V1 -e -s --cmd "echon resolve(argv(0))" --cmd "echo ''" --cmd quit "$1" 2>&1
-	}
+		THEMIS_BIN=$("${THEMIS_VIM}" -u NONE -i NONE -N -X -V1 -e -s --cmd "echon resolve(argv(0))" --cmd "echo ''" --cmd quit "$0" 2>&1)
+	fi
+
+	THEMIS_HOME=$(cd "$(dirname "$THEMIS_BIN")/.." && pwd -P)
 fi
 
-: "${THEMIS_HOME:=$(dirname "$(dirname "$(realpath "$0")")")}"
 
 STARTUP_SCRIPT="${THEMIS_HOME}/macros/themis_startup.vim"
 if [ ! -f "${STARTUP_SCRIPT}" ]; then


### PR DESCRIPTION
Removing the usage of Bash-specific features (called *bashism*) will improve the portability on POSIX systems [whose `/bin/sh` is not a Bash](https://wiki.ubuntu.com/DashAsBinSh).
In addition, `set -e` is good for diagnostics and this will help users to find out what is wrong with their systems.

## Description
The things on the following list are not specified in [POSIX](https://ja.wikipedia.org/wiki/POSIX), and thus we should not rely on them:

* type

The following things are specified in POSIX and therefore we are safe to use them:

* [Paramater substitution with an alternate value](http://www.tldp.org/LDP/abs/html/parameter-substitution.html#PARAMALTV) `${THEMIS_HOME+x}`
  This is used to detect `$THEMIS_HOME` is **unset**. (c. f. `THEMIS_HOME=` **sets** `$THEMIS_HOME ` empty)
* [Paramater substituion with a default value](http://www.tldp.org/LDP/abs/html/parameter-substitution.html#DEFPARAM1) `${THEMIS_VIM-vim}` `${THEMIS_ARGS--e -s}`
* [dirname(1)](http://pubs.opengroup.org/onlinepubs/009696799/utilities/dirname.html)
* [pwd -P](http://pubs.opengroup.org/onlinepubs/009695399/utilities/pwd.html)

realpath(1) and readlink(1) is not defined in POSIX but modern UNIX-like systems must have at least one of them.

* The `readlink` binary exists almost all the systems.
* `readlink -f` is GNU-specific and not supported by BSD readlink (FreeBSD and macOS).
* Ubuntu before trusty and macOS does not have `realpath`.
* Vim's `resolve` will work everywhere but some types of useful errors are thrown away (such as `-bash: vim: command not found`)