### PR TITLE
Fix cursor issue on command prompt with "normal" command

### DIFF
--- a/bin/themis.bat
+++ b/bin/themis.bat
@@ -19,7 +19,7 @@ if not exist "%STARTUP_SCRIPT%" (
 rem FIXME: Some wrong case exists in passing the argument list.
 rem DO NOT directly output the result to command prompt while 'normal' command in Vim script
 rem will move a cursor of command prompt in that case.
-set THEMIS_LOG="%USERPROFILE%\AppData\Local\Temp\themis.log"
+set THEMIS_LOG="%TMP%\themis.log"
 %THEMIS_VIM% -u NONE -i NONE -n -N %THEMIS_ARGS% --cmd "source %STARTUP_SCRIPT%" -- %* 2>&1 > %THEMIS_LOG%
 type %THEMIS_LOG%
 del %THEMIS_VIM%

--- a/bin/themis.bat
+++ b/bin/themis.bat
@@ -22,7 +22,6 @@ rem will move a cursor of command prompt in that case.
 set THEMIS_LOG="%USERPROFILE%\AppData\Local\Temp\themis.log"
 %THEMIS_VIM% -u NONE -i NONE -n -N %THEMIS_ARGS% --cmd "source %STARTUP_SCRIPT%" -- %* 2>&1 > %THEMIS_LOG%
 type %THEMIS_LOG%
-pause
 del %THEMIS_VIM%
 exit /b %ERRORLEVEL%
 

--- a/bin/themis.bat
+++ b/bin/themis.bat
@@ -17,7 +17,13 @@ if not exist "%STARTUP_SCRIPT%" (
 )
 
 rem FIXME: Some wrong case exists in passing the argument list.
-%THEMIS_VIM% -u NONE -i NONE -n -N %THEMIS_ARGS% --cmd "source %STARTUP_SCRIPT%" -- %* 2>&1
+rem DO NOT directly output the result to command prompt while 'normal' command in Vim script
+rem will move a cursor of command prompt in that case.
+set THEMIS_LOG="%USERPROFILE%\AppData\Local\Temp\themis.log"
+%THEMIS_VIM% -u NONE -i NONE -n -N %THEMIS_ARGS% --cmd "source %STARTUP_SCRIPT%" -- %* 2>&1 > %THEMIS_LOG%
+type %THEMIS_LOG%
+pause
+del %THEMIS_VIM%
 exit /b %ERRORLEVEL%
 
 :get_realpath

--- a/bin/themis.bat
+++ b/bin/themis.bat
@@ -22,7 +22,7 @@ rem will move a cursor of command prompt in that case.
 set THEMIS_LOG="%TMP%\themis.log"
 %THEMIS_VIM% -u NONE -i NONE -n -N %THEMIS_ARGS% --cmd "source %STARTUP_SCRIPT%" -- %* 2>&1 > %THEMIS_LOG%
 type %THEMIS_LOG%
-del %THEMIS_VIM%
+del %THEMIS_LOG%
 exit /b %ERRORLEVEL%
 
 :get_realpath


### PR DESCRIPTION
Before
https://dl.dropboxusercontent.com/u/1529319/themis1.mkv

After
https://dl.dropboxusercontent.com/u/1529319/themis2.mkv

In Vim sciprt called from `gina#core#buffer` test use `normal` command and that seems to move cursor of command prompt as well.