### PR TITLE
Delete all the buffers on start-up

### DIFF
--- a/macros/themis_startup.vim
+++ b/macros/themis_startup.vim
@@ -24,6 +24,11 @@ function! s:start() abort
   if 0 < len(args)
     " Remove arglist for plain environment
     execute '1,' . len(args) . 'argdelete'
+
+    " Delete all the buffers
+    for bufnr in range(1, bufnr('$'))
+      execute bufnr 'bwipeout!'
+    endfor
   endif
 
   return themis#command#start(args)


### PR DESCRIPTION
When executing `themis --reporter spec`, there are two buffers `--reporter` and `spec`. This pull request deletes these buffers.