### PR TITLE
Add assert.not_exists()

### DIFF
--- a/autoload/themis/helper/assert.vim
+++ b/autoload/themis/helper/assert.vim
@@ -289,6 +289,17 @@ function! s:assert_exists(expr, ...) abort
   return 1
 endfunction
 
+function! s:assert_not_exists(expr, ...) abort
+  if exists(a:expr)
+    throw s:failure([
+    \   'The target was expected not to exist, but it actually exists.',
+    \   '',
+    \   '    target: ' . string(a:expr),
+    \ ], a:000)
+  endif
+  return 1
+endfunction
+
 function! s:assert_cmd_exists(expr, ...) abort
   let cmd = a:expr[0] ==# ':' ? a:expr : ':' . a:expr
   if exists(cmd) != 2

--- a/doc/themis.txt
+++ b/doc/themis.txt
@@ -362,7 +362,8 @@ Others
 |themis-helper-assert-length_of()|
 |themis-helper-assert-key_exists()| / |themis-helper-assert-key_not_exists()|
 |themis-helper-assert-has_key()|
-|themis-helper-assert-exists()| / |themis-helper-assert-cmd_exists()|
+|themis-helper-assert-exists()| / |themis-helper-assert-not-exists()|
+|themis-helper-assert-cmd_exists()|
 |themis-helper-assert-empty()|
 |themis-helper-assert-not_empty()|
 
@@ -727,6 +728,11 @@ assert.has_key({list}, {index} [, {message}])
 assert.exists({expr} [, {message}])	*themis-helper-assert-exists()*
 	Checks {expr} by |exists()|.
 	Note that this can not use for |local-variable| and |script-variable|.
+
+assert.not_exists({expr} [, {message}])	*themis-helper-assert-not-exists()*
+	Checks {expr} does not exists by checking |exists()| returns 0.
+	Note that this can not be used for |local-variable| and
+	|script-variable|.
 
 assert.cmd_exists({cmd} [, {message}])	*themis-helper-assert-cmd_exists()*
 	Checks {cmd} by |exists()| strictly(full match with a command).

--- a/test/helper/assert.vimspec
+++ b/test/helper/assert.vimspec
@@ -724,6 +724,28 @@ Describe helper-assert
     End
   End
 
+  Describe .not_exists()
+    Before each
+      let g:the_value_which_exists = 1
+    End
+    After each
+      unlet g:the_value_which_exists
+    End
+    It throws report when the value exists
+      call s:check_throw('not_exists', ['g:the_value_which_exists'], 'The target was expected not to exist')
+    End
+    It does not throw report when the value does not exist
+      call s:assert.not_exists('g:the_value_which_does_not_exist')
+    End
+    It returns truthy value when check was successful
+      call s:assert.truthy(s:assert.not_exists('g:the_value_which_does_not_exists'))
+    End
+    It accepts an optional message
+      call s:assert.not_exists('g:the_value_which_not_exists', 'error message')
+      call s:check_throw('not_exists', ['g:the_value_which_exists', 'error message'], 'error message')
+    End
+  End
+
   Describe .cmd_exists()
     It throws report when the ex command does not exists
       call s:check_throw('cmd_exists', ['NotExistCommand'], 'The ex command was expected to exist')


### PR DESCRIPTION
`assert.exists()` exists but `assert.not_exists()` does not exist. I added it since it is more useful than `assert.false(exists(expr))` in terms of an error message.