### PR TITLE
Fix 'expected type' in error message of IsNotXXX({expr})

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
       env:
         - VIM_VERSION=master
     - os: osx
-      osx_image: xcode8.3
 
 addons:
   apt:
@@ -28,6 +27,9 @@ addons:
       - ruby-dev
       - liblua5.1-0-dev
       - lua5.1
+  homebrew:
+    packages:
+      - macvim
 
 cache:
   directories:
@@ -67,9 +69,6 @@ install:
         export PATH=/tmp/vim/${VIM_VERSION}/build/bin:${PATH}
       ;;
       osx)
-        export HOMEBREW_NO_AUTO_UPDATE=1
-        brew update
-        brew install macvim --with-override-system-vim --with-lua
       ;;
       *)
         echo "Unknown value of \${TRAVIS_OS_NAME}: ${TRAVIS_OS_NAME}"

--- a/autoload/themis/helper/assert.vim
+++ b/autoload/themis/helper/assert.vim
@@ -373,7 +373,7 @@ function! s:check_type(value, expected_types, not, additional_message) abort
     throw s:failure([
     \   printf(msg . ', but it was%s the case.', expect, type_names, but),
     \   '',
-    \   printf('    %s expected type: %s', pad, type_names),
+    \   printf('    %s expected type:%s %s', pad, expect, type_names),
     \   printf('    %s      got type: %s', pad, got_type),
     \   printf('    %s     got value: %s', pad, string(a:value)),
     \ ], a:additional_message)

--- a/autoload/themis/util.vim
+++ b/autoload/themis/util.vim
@@ -193,6 +193,7 @@ function! themis#util#funcdata(func) abort
   let signature = matchstr(lines[0], '^\s*\zs.*')
   let file = matchstr(lines[1], '^\t\%(Last set from\|.\{-}:\)\s*\zs.*$')
   let file = substitute(file, '[/\\]\+', '/', 'g')
+  let file = substitute(file, ' line \d\+$', '', '')
   let arguments = split(matchstr(signature, '(\zs.*\ze)'), '\s*,\s*')
   let has_extra_arguments = get(arguments, -1, '') ==# '...'
   let arity = len(arguments) - (has_extra_arguments ? 1 : 0)


### PR DESCRIPTION
Test case

```vim
Describe something
    It should not pass
        Assert IsNotNone(v:null)
    End
End
```

shows following assertion error message.

```
not ok 1 - something should not pass
# Error occurred line:
#   1:         Assert IsNotNone(v:null)
# The type of value was not expected to be none, but it was the case.
#
#          expected type: none
#               got type: none
#              got value: v:null
```

However, here I think expected type should be 'not none' since
`IsNotNone()` expects non-none value.

By this patch, the error message is fixed as follows:

```
not ok 1 - something should not pass
# Error occurred line:
#   1:         Assert IsNotNone(v:null)
# The type of value was not expected to be none, but it was the case.
#
#          expected type: not none
#               got type: none
#              got value: v:null
```