### PR TITLE
Fix assertions considering v:true and v:false

### DIFF
--- a/autoload/themis/helper/assert.vim
+++ b/autoload/themis/helper/assert.vim
@@ -23,6 +23,10 @@ let s:func_aliases = {
 \   'not_equal': 'not_equals',
 \ }
 
+" Note: v:true and v:false were added at Vim 7.4.1154
+let s:true = get(v:, 'true', 1)
+let s:false = get(v:, 'false', 0)
+
 for s:aliased_type in keys(s:type_aliases)
   let s:func_aliases['is_' . s:aliased_type] =
   \   'is_' . s:type_aliases[s:aliased_type]
@@ -43,7 +47,7 @@ function! s:assert_skip(mes) abort
 endfunction
 
 function! s:assert_true(value, ...) abort
-  if a:value isnot 1
+  if a:value isnot 1 && a:value isnot s:true
     throw s:failure([
     \   'The true value was expected, but it was not the case.',
     \   '',
@@ -55,7 +59,7 @@ function! s:assert_true(value, ...) abort
 endfunction
 
 function! s:assert_false(value, ...) abort
-  if a:value isnot 0
+  if a:value isnot 0 && a:value isnot s:false
     throw s:failure([
     \   'The false value was expected, but it was not the case.',
     \   '',
@@ -68,7 +72,7 @@ endfunction
 
 function! s:assert_truthy(value, ...) abort
   let t = type(a:value)
-  if !(t == type(0) || t == type('')) || !a:value
+  if !(t == type(0) || t == type('') || t == type(s:true)) || !a:value
     throw s:failure([
     \   'The truthy value was expected, but it was not the case.',
     \   '',
@@ -81,7 +85,7 @@ endfunction
 
 function! s:assert_falsy(value, ...) abort
   let t = type(a:value)
-  if (t != type(0) && t != type('')) || a:value
+  if (t != type(0) && t != type('') && t != type(s:false)) || a:value
     throw s:failure([
     \   'The falsy value was expected, but it was not the case.',
     \   '',

--- a/doc/themis.txt
+++ b/doc/themis.txt
@@ -564,10 +564,10 @@ assert.skip({message})			*themis-helper-assert-skip()*
 	Pass a test as SKIP with {message}.
 
 assert.true({value} [, {message}])	*themis-helper-assert-true()*
-	Checks {value} is 1.
+	Checks {value} is 1 or |v:true|.
 
 assert.false({value} [, {message}])	*themis-helper-assert-false()*
-	Checks {value} is 0.
+	Checks {value} is 0 or |v:false|.
 
 assert.truthy({value} [, {message}])	*themis-helper-assert-truthy()*
 	Checks {value} is truthy value.

--- a/test/helper/assert.vimspec
+++ b/test/helper/assert.vimspec
@@ -26,6 +26,9 @@ Describe helper-assert
   Describe .true()
     It checks value is true
       call s:assert.true(1)
+      if exists('v:true')
+        call s:assert.true(v:true)
+      endif
     End
     It checks value strictly
       call s:check_throw('true', [100])
@@ -46,6 +49,9 @@ Describe helper-assert
   Describe .false()
     It checks value is false
       call s:assert.false(0)
+      if exists('v:false')
+        call s:assert.false(v:false)
+      endif
     End
     It checks value strictly
       call s:check_throw('false', [''])
@@ -67,6 +73,9 @@ Describe helper-assert
       call s:assert.truthy(1)
       call s:assert.truthy(100)
       call s:assert.truthy('1')
+      if exists('v:true')
+        call s:assert.truthy(v:true)
+      endif
     End
     It throws a report when value is zero or not a number
       call s:check_throw('truthy', [0])
@@ -88,6 +97,9 @@ Describe helper-assert
       call s:assert.falsy(0)
       call s:assert.falsy('')
       call s:assert.falsy('0')
+      if exists('v:false')
+        call s:assert.falsy(v:false)
+      endif
     End
     It throws a report when value is not zero or not a number
       call s:check_throw('falsy', [1])


### PR DESCRIPTION
`v:true` and `v:false` are not considered as boolean value. For example,

```vim
" Assertion fails
assert.true(v:true)
```

This patch fixes the issue. They were added at 7.4.1154 and themis.vim supports Vim 7.4.0+. So this patch considers the environment where `v:true` and `v:false` are not defined.