### PR TITLE
Fix document of expect-to_be_less_than_or_equal()

### DIFF
--- a/doc/themis.txt
+++ b/doc/themis.txt
@@ -841,7 +841,7 @@ expect({left}).to_be_less_than({right})
 	Compares by |expr-<#|
 
 			*themis-helper-expect-to_be_less_than_or_equal()*
-expect({left}).to_be_less_than({right})
+expect({left}).to_be_less_than_or_equal({right})
 	Compares by |expr-<=#|
 
 expect({actual}).to_equal({expect})	*themis-helper-expect-to_equal()*


### PR DESCRIPTION
There were two `expect({left}).to_be_less_than({right})` listed in the document. The latter one would be `expect({left}).to_be_less_than_or_equal({right})` probably?