### PR TITLE
Add runtime syntax/vim/ directory.

### DIFF
--- a/syntax/vimspec.vim
+++ b/syntax/vimspec.vim
@@ -10,7 +10,7 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-runtime! syntax/vim.vim
+runtime! syntax/vim.vim syntax/vim/*.vim
 
 syntax keyword vimspecCommand describe Describe skipwhite nextgroup=vimspecDescription
 syntax keyword vimspecCommand context Context skipwhite nextgroup=vimspecDescription


### PR DESCRIPTION
The reasons to add this is
  - This is reasonable on the basis of $VIMRUNTIME/syntax/synload.vim .
    ( synload.vim is used in the process of `:h syntax-loading` )
  - neovim uses this for generated code.

https://github.com/vim/vim/blob/v8.2.0259/runtime/syntax/synload.vim#L57

