### PR TITLE
Add expect.with_message

### DIFF
--- a/autoload/themis/helper/expect.vim
+++ b/autoload/themis/helper/expect.vim
@@ -12,6 +12,12 @@ function themis#helper#expect#_create_expect(actual) abort
   return expect
 endfunction
 
+function s:expect.with_message(message) abort
+  let self._error_message = a:message
+  let self.not._error_message = a:message
+  return self
+endfunction
+
 function s:matcher_impl(name, f, error_msg, ...) dict abort
   let result = call(a:f, [self._actual] + a:000)
   if self._negate
@@ -20,7 +26,12 @@ function s:matcher_impl(name, f, error_msg, ...) dict abort
   if result
     return {'and' : self}
   else
-    throw themis#failure(call(a:error_msg, [self._negate, a:name, self._actual] + a:000))
+    if has_key(self, "_error_message")
+      let msg = self._error_message
+    else
+      let msg = call(a:error_msg, [self._negate, a:name, self._actual] + a:000)
+    endif
+    throw themis#failure(msg)
   endif
 endfunction
 

--- a/doc/themis.txt
+++ b/doc/themis.txt
@@ -823,7 +823,12 @@ Expect-helper also provides not object.
 It is useful to invert the result of the test.
 >
 	call s:expect(2 + 3).not.to_equal(42)
-
+<
+					*themis-helper-expect-with_message()*
+If you want to override failure message, you can use with_message().
+>
+	call s:expect(1).with_message("not equal!").to_be_equal(1)
+<
 Of course you can easily make a custom matcher.
 See |themis#helper#expect#define_matcher()|
 

--- a/test/helper/expect.vim
+++ b/test/helper/expect.vim
@@ -267,6 +267,29 @@ function s:helper.__expect__() abort
     endfunction
   endfunction
 
+  function expect.__with_message__() abort
+    let with_message = themis#suite('.with_message()')
+    function with_message.does_not_affect_regular_case() abort
+      call s:expect(1).to_be_true()
+    endfunction
+    function with_message.shows_specified_message_if_failed() abort
+      try
+        call s:expect(0).with_message("error").to_be_true()
+      catch
+        if v:exception !=# "themis: report: failure: error"
+          throw printf('themis: report: failure: message "error" expected but thrown wrong exception: %s', v:exception)
+        endif
+      endtry
+      try
+        call s:expect(0).with_message("error").not.to_be_false()
+      catch
+        if v:exception !=# "themis: report: failure: error"
+          throw printf('themis: report: failure: message "error" expected but thrown wrong exception: %s', v:exception)
+        endif
+      endtry
+    endfunction
+  endfunction
+
 endfunction
 
 function s:check_throw(target, actual, ...) abort


### PR DESCRIPTION
Will close #70

<!-- Please describe all sections -->

### Is your suggesting new feature related to a problem?
<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
described in #70 

### Describe the solution you'd like
<!-- A clear and concise description of what you want to happen. -->
Add `with_message` method to expect helper object:
```vim
s:expect(something).with_message('you are the one!').to_equal(1)
```

### Additional context
<!-- Add any other context or screenshots about the new feature here. -->

